### PR TITLE
fix: resolve react and react-dom dependency conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,6 @@
     "format:check": "prettier . --check",
     "ci": "pnpm run lint && pnpm run format:check && CI=true pnpm run test:coverage && pnpm run build"
   },
-  "dependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  },
   "devDependencies": {
     "@testing-library/dom": "^9.3.3",
     "@testing-library/react": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,14 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  react:
-    specifier: 18.2.0
-    version: 18.2.0
-  react-dom:
-    specifier: 18.2.0
-    version: 18.2.0(react@18.2.0)
-
 devDependencies:
   '@testing-library/dom':
     specifier: ^9.3.3
@@ -64,6 +56,12 @@ devDependencies:
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
+  react:
+    specifier: ^18.2.0
+    version: 18.2.0
+  react-dom:
+    specifier: ^18.2.0
+    version: 18.2.0(react@18.2.0)
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
@@ -2663,6 +2661,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2804,6 +2803,7 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: true
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
@@ -3154,6 +3154,7 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: true
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3177,6 +3178,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: true
 
   /reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
@@ -3300,6 +3302,7 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
+    dev: true
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}


### PR DESCRIPTION
The specification of react and react-dom @18 causes npm to pull a version of react at that version within the package directory. This causes a runtime issue if this is not the version of react that is actually used by consumers when they attempt to serve those dependencies without the version matching. `peerDependencies` suggests that this package should be compatible with react and react-dom @17 as well, so the expectation is that consumers can use v17 of those dependencies.

`peerDependencies` already specify react and react-dom @17/@18, so the necessity of these packages is already conveyed to consuming packages. `devDependencies` already specifies react and react-dom @18 for use for development of this package.

Closes #26