### PR TITLE
Add isOnUnmount to onSave callback

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -4,7 +4,7 @@ export interface CommonProps<TData, TReturn> {
   /** The controlled form value to be auto saved   */
   data: TData;
   /** Callback function to save your data */
-  onSave: (data: TData) => Promise<TReturn> | TReturn | void;
+  onSave: (data: TData, isOnUnmount: boolean) => Promise<TReturn> | TReturn | void;
   /** The number of milliseconds between save attempts. Defaults to 2000 */
   interval?: number;
   /** Set to false if you do not want the save function to fire on unmount */

--- a/src/useAutosave.tsx
+++ b/src/useAutosave.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { CommonProps } from './props';
 import useDebounce from './useDebounce';
 
@@ -18,7 +18,7 @@ function useAutosave<TData, TReturn>({
     if (initialRender.current) {
       initialRender.current = false;
     } else {
-      handleSave.current(debouncedValueToSave);
+      handleSave.current(debouncedValueToSave, false);
     }
   }, [debouncedValueToSave]);
 
@@ -33,7 +33,7 @@ function useAutosave<TData, TReturn>({
   useEffect(
     () => () => {
       if (saveOnUnmount) {
-        handleSave.current(valueOnCleanup.current);
+        handleSave.current(valueOnCleanup.current, true);
       }
     },
     [saveOnUnmount],


### PR DESCRIPTION
Hello there!

I'm currently using this library for autosave, and I must say I appreciate its simplicity. However, I've encountered a specific use case that the library doesn't quite address. I perform a request in each onSave, but I'd prefer not to invalidate my cache in every request, I prefer to do only when the component unmount. As of now, I can achieve this by creating a separate useEffect just for that purpose or implementing it the existing onSave callback.

I'm curious to know if you've considered implementing a feature in the library. It would be great if the library could provide an option to know if is an onmount callback or not.

What are your thoughts on this idea?